### PR TITLE
Delete .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "arduinolibs"]
-	path = arduinolibs
-	url = https://github.com/Agponics/arduinolibs


### PR DESCRIPTION
I decided against using git submodules for the arduino libraries. Because the way the Arduino IDE works they need to be manually copied anyways.